### PR TITLE
Correct the instruction set from `rv32ecxw` to `rv32ec`

### DIFF
--- a/software/calibrator/makefile
+++ b/software/calibrator/makefile
@@ -2,7 +2,7 @@
 # Project:  CH32V003 Joypad Calibrator
 # Author:   Stefan Wagner
 # Year:     2023
-# URL:      https://github.com/wagiminator    
+# URL:      https://github.com/wagiminator
 # ===================================================================================
 # Type "make help" in the command line.
 # ===================================================================================
@@ -27,7 +27,7 @@ CLEAN    = rm -f *.lst *.obj *.cof *.list *.map *.eep.hex *.o *.d
 
 # Compiler Flags
 CFLAGS   = -g -Os -flto -ffunction-sections -fno-builtin -static-libgcc -nostdlib
-CFLAGS  += -march=rv32ecxw -mabi=ilp32e -DF_CPU=$(F_CPU) -Wall
+CFLAGS  += -march=rv32ec -mabi=ilp32e -DF_CPU=$(F_CPU) -Wall
 CFLAGS  += -I/usr/include/newlib -I$(INCLUDE) -I.
 LDFLAGS  = -T$(LINKER)/ch32v003.ld -Wl,--gc-sections -L$(LINKER) -lgcc
 CFILES   = $(SKETCH) $(wildcard $(INCLUDE)/*.c) $(wildcard $(INCLUDE)/*.s)

--- a/software/tiny_arkanoid/makefile
+++ b/software/tiny_arkanoid/makefile
@@ -2,7 +2,7 @@
 # Project:  CH32V003 Tiny Arkanoid
 # Author:   Stefan Wagner
 # Year:     2023
-# URL:      https://github.com/wagiminator    
+# URL:      https://github.com/wagiminator
 # ===================================================================================
 # Type "make help" in the command line.
 # ===================================================================================
@@ -27,7 +27,7 @@ CLEAN    = rm -f *.lst *.obj *.cof *.list *.map *.eep.hex *.o *.d
 
 # Compiler Flags
 CFLAGS   = -g -Os -flto -ffunction-sections -fno-builtin -static-libgcc -nostdlib
-CFLAGS  += -march=rv32ecxw -mabi=ilp32e -DF_CPU=$(F_CPU) -Wall
+CFLAGS  += -march=rv32ec -mabi=ilp32e -DF_CPU=$(F_CPU) -Wall
 CFLAGS  += -I/usr/include/newlib -I$(INCLUDE) -I.
 LDFLAGS  = -T$(LINKER)/ch32v003.ld -Wl,--gc-sections -L$(LINKER) -lgcc
 CFILES   = $(SKETCH) $(wildcard $(INCLUDE)/*.c) $(wildcard $(INCLUDE)/*.s)

--- a/software/tiny_invaders/makefile
+++ b/software/tiny_invaders/makefile
@@ -2,7 +2,7 @@
 # Project:  CH32V003 Tiny Invaders
 # Author:   Stefan Wagner
 # Year:     2023
-# URL:      https://github.com/wagiminator    
+# URL:      https://github.com/wagiminator
 # ===================================================================================
 # Type "make help" in the command line.
 # ===================================================================================
@@ -27,7 +27,7 @@ CLEAN    = rm -f *.lst *.obj *.cof *.list *.map *.eep.hex *.o *.d
 
 # Compiler Flags
 CFLAGS   = -g -Os -flto -ffunction-sections -fno-builtin -static-libgcc -nostdlib
-CFLAGS  += -march=rv32ecxw -mabi=ilp32e -DF_CPU=$(F_CPU) -Wall
+CFLAGS  += -march=rv32ec -mabi=ilp32e -DF_CPU=$(F_CPU) -Wall
 CFLAGS  += -I/usr/include/newlib -I$(INCLUDE) -I.
 LDFLAGS  = -T$(LINKER)/ch32v003.ld -Wl,--gc-sections -L$(LINKER) -lgcc
 CFILES   = $(SKETCH) $(wildcard $(INCLUDE)/*.c) $(wildcard $(INCLUDE)/*.s)

--- a/software/tiny_lander/makefile
+++ b/software/tiny_lander/makefile
@@ -2,7 +2,7 @@
 # Project:  CH32V003 Tiny Lander
 # Author:   Stefan Wagner
 # Year:     2023
-# URL:      https://github.com/wagiminator    
+# URL:      https://github.com/wagiminator
 # ===================================================================================
 # Type "make help" in the command line.
 # ===================================================================================
@@ -27,7 +27,7 @@ CLEAN    = rm -f *.lst *.obj *.cof *.list *.map *.eep.hex *.o *.d
 
 # Compiler Flags
 CFLAGS   = -g -Os -flto -ffunction-sections -fno-builtin -static-libgcc -nostdlib
-CFLAGS  += -march=rv32ecxw -mabi=ilp32e -DF_CPU=$(F_CPU) -Wall
+CFLAGS  += -march=rv32ec -mabi=ilp32e -DF_CPU=$(F_CPU) -Wall
 CFLAGS  += -I/usr/include/newlib -I$(INCLUDE) -I.
 LDFLAGS  = -T$(LINKER)/ch32v003.ld -Wl,--gc-sections -L$(LINKER) -lgcc
 CFILES   = $(SKETCH) $(wildcard $(INCLUDE)/*.c) $(wildcard $(INCLUDE)/*.s)

--- a/software/tiny_pacman/makefile
+++ b/software/tiny_pacman/makefile
@@ -2,7 +2,7 @@
 # Project:  CH32V003 Tiny Pacman
 # Author:   Stefan Wagner
 # Year:     2023
-# URL:      https://github.com/wagiminator    
+# URL:      https://github.com/wagiminator
 # ===================================================================================
 # Type "make help" in the command line.
 # ===================================================================================
@@ -27,7 +27,7 @@ CLEAN    = rm -f *.lst *.obj *.cof *.list *.map *.eep.hex *.o *.d
 
 # Compiler Flags
 CFLAGS   = -g -Os -flto -ffunction-sections -fno-builtin -static-libgcc -nostdlib
-CFLAGS  += -march=rv32ecxw -mabi=ilp32e -DF_CPU=$(F_CPU) -Wall
+CFLAGS  += -march=rv32ec -mabi=ilp32e -DF_CPU=$(F_CPU) -Wall
 CFLAGS  += -I/usr/include/newlib -I$(INCLUDE) -I.
 LDFLAGS  = -T$(LINKER)/ch32v003.ld -Wl,--gc-sections -L$(LINKER) -lgcc
 CFILES   = $(SKETCH) $(wildcard $(INCLUDE)/*.c) $(wildcard $(INCLUDE)/*.s)

--- a/software/tiny_tris/makefile
+++ b/software/tiny_tris/makefile
@@ -2,7 +2,7 @@
 # Project:  CH32V003 Tiny Tris
 # Author:   Stefan Wagner
 # Year:     2023
-# URL:      https://github.com/wagiminator    
+# URL:      https://github.com/wagiminator
 # ===================================================================================
 # Type "make help" in the command line.
 # ===================================================================================
@@ -27,7 +27,7 @@ CLEAN    = rm -f *.lst *.obj *.cof *.list *.map *.eep.hex *.o *.d
 
 # Compiler Flags
 CFLAGS   = -g -Os -flto -ffunction-sections -fno-builtin -static-libgcc -nostdlib
-CFLAGS  += -march=rv32ecxw -mabi=ilp32e -DF_CPU=$(F_CPU) -Wall
+CFLAGS  += -march=rv32ec -mabi=ilp32e -DF_CPU=$(F_CPU) -Wall
 CFLAGS  += -I/usr/include/newlib -I$(INCLUDE) -I.
 LDFLAGS  = -T$(LINKER)/ch32v003.ld -Wl,--gc-sections -L$(LINKER) -lgcc
 CFILES   = $(SKETCH) $(wildcard $(INCLUDE)/*.c) $(wildcard $(INCLUDE)/*.s)


### PR DESCRIPTION
Correct the instruction set from `rv32ecxw` to `rv32ec`.

The calibrator and all the games are successfully built after the change.