### PR TITLE
Fix GPIO macros for port D

### DIFF
--- a/software/calibrator/include/gpio.h
+++ b/software/calibrator/include/gpio.h
@@ -90,7 +90,7 @@ enum{ PA0, PA1, PA2, PA3, PA4, PA5, PA6, PA7,
   ((PIN>=PC0)&&(PIN<=PC7) ? ( GPIOC->CFGLR =  (GPIOC->CFGLR                          \
                                            & ~((uint32_t)0b1111<<(((PIN)&7)<<2)))    \
                                            |  ((uint32_t)0b0100<<(((PIN)&7)<<2)) ) : \
-  ((PIN>=PC0)&&(PIN<=PC7) ? ( GPIOD->CFGLR =  (GPIOD->CFGLR                          \
+  ((PIN>=PD0)&&(PIN<=PD7) ? ( GPIOD->CFGLR =  (GPIOD->CFGLR                          \
                                            & ~((uint32_t)0b1111<<(((PIN)&7)<<2)))    \
                                            |  ((uint32_t)0b0100<<(((PIN)&7)<<2)) ) : \
 (0))))
@@ -154,7 +154,7 @@ enum{ PA0, PA1, PA2, PA3, PA4, PA5, PA6, PA7,
   ((PIN>=PC0)&&(PIN<=PC7) ? ( GPIOC->CFGLR =  (GPIOC->CFGLR                          \
                                            & ~((uint32_t)0b1111<<(((PIN)&7)<<2)))    \
                                            |  ((uint32_t)0b0001<<(((PIN)&7)<<2)) ) : \
-  ((PIN>=PC0)&&(PIN<=PC7) ? ( GPIOD->CFGLR =  (GPIOD->CFGLR                          \
+  ((PIN>=PD0)&&(PIN<=PD7) ? ( GPIOD->CFGLR =  (GPIOD->CFGLR                          \
                                            & ~((uint32_t)0b1111<<(((PIN)&7)<<2)))    \
                                            |  ((uint32_t)0b0001<<(((PIN)&7)<<2)) ) : \
 (0))))
@@ -170,7 +170,7 @@ enum{ PA0, PA1, PA2, PA3, PA4, PA5, PA6, PA7,
   ((PIN>=PC0)&&(PIN<=PC7) ? ( GPIOC->CFGLR =  (GPIOC->CFGLR                          \
                                            & ~((uint32_t)0b1111<<(((PIN)&7)<<2)))    \
                                            |  ((uint32_t)0b0101<<(((PIN)&7)<<2)) ) : \
-  ((PIN>=PC0)&&(PIN<=PC7) ? ( GPIOD->CFGLR =  (GPIOD->CFGLR                          \
+  ((PIN>=PD0)&&(PIN<=PD7) ? ( GPIOD->CFGLR =  (GPIOD->CFGLR                          \
                                            & ~((uint32_t)0b1111<<(((PIN)&7)<<2)))    \
                                            |  ((uint32_t)0b0101<<(((PIN)&7)<<2)) ) : \
 (0))))

--- a/software/tiny_arkanoid/include/gpio.h
+++ b/software/tiny_arkanoid/include/gpio.h
@@ -90,7 +90,7 @@ enum{ PA0, PA1, PA2, PA3, PA4, PA5, PA6, PA7,
   ((PIN>=PC0)&&(PIN<=PC7) ? ( GPIOC->CFGLR =  (GPIOC->CFGLR                          \
                                            & ~((uint32_t)0b1111<<(((PIN)&7)<<2)))    \
                                            |  ((uint32_t)0b0100<<(((PIN)&7)<<2)) ) : \
-  ((PIN>=PC0)&&(PIN<=PC7) ? ( GPIOD->CFGLR =  (GPIOD->CFGLR                          \
+  ((PIN>=PD0)&&(PIN<=PD7) ? ( GPIOD->CFGLR =  (GPIOD->CFGLR                          \
                                            & ~((uint32_t)0b1111<<(((PIN)&7)<<2)))    \
                                            |  ((uint32_t)0b0100<<(((PIN)&7)<<2)) ) : \
 (0))))
@@ -154,7 +154,7 @@ enum{ PA0, PA1, PA2, PA3, PA4, PA5, PA6, PA7,
   ((PIN>=PC0)&&(PIN<=PC7) ? ( GPIOC->CFGLR =  (GPIOC->CFGLR                          \
                                            & ~((uint32_t)0b1111<<(((PIN)&7)<<2)))    \
                                            |  ((uint32_t)0b0001<<(((PIN)&7)<<2)) ) : \
-  ((PIN>=PC0)&&(PIN<=PC7) ? ( GPIOD->CFGLR =  (GPIOD->CFGLR                          \
+  ((PIN>=PD0)&&(PIN<=PD7) ? ( GPIOD->CFGLR =  (GPIOD->CFGLR                          \
                                            & ~((uint32_t)0b1111<<(((PIN)&7)<<2)))    \
                                            |  ((uint32_t)0b0001<<(((PIN)&7)<<2)) ) : \
 (0))))
@@ -170,7 +170,7 @@ enum{ PA0, PA1, PA2, PA3, PA4, PA5, PA6, PA7,
   ((PIN>=PC0)&&(PIN<=PC7) ? ( GPIOC->CFGLR =  (GPIOC->CFGLR                          \
                                            & ~((uint32_t)0b1111<<(((PIN)&7)<<2)))    \
                                            |  ((uint32_t)0b0101<<(((PIN)&7)<<2)) ) : \
-  ((PIN>=PC0)&&(PIN<=PC7) ? ( GPIOD->CFGLR =  (GPIOD->CFGLR                          \
+  ((PIN>=PD0)&&(PIN<=PD7) ? ( GPIOD->CFGLR =  (GPIOD->CFGLR                          \
                                            & ~((uint32_t)0b1111<<(((PIN)&7)<<2)))    \
                                            |  ((uint32_t)0b0101<<(((PIN)&7)<<2)) ) : \
 (0))))

--- a/software/tiny_invaders/include/gpio.h
+++ b/software/tiny_invaders/include/gpio.h
@@ -90,7 +90,7 @@ enum{ PA0, PA1, PA2, PA3, PA4, PA5, PA6, PA7,
   ((PIN>=PC0)&&(PIN<=PC7) ? ( GPIOC->CFGLR =  (GPIOC->CFGLR                          \
                                            & ~((uint32_t)0b1111<<(((PIN)&7)<<2)))    \
                                            |  ((uint32_t)0b0100<<(((PIN)&7)<<2)) ) : \
-  ((PIN>=PC0)&&(PIN<=PC7) ? ( GPIOD->CFGLR =  (GPIOD->CFGLR                          \
+  ((PIN>=PD0)&&(PIN<=PD7) ? ( GPIOD->CFGLR =  (GPIOD->CFGLR                          \
                                            & ~((uint32_t)0b1111<<(((PIN)&7)<<2)))    \
                                            |  ((uint32_t)0b0100<<(((PIN)&7)<<2)) ) : \
 (0))))
@@ -154,7 +154,7 @@ enum{ PA0, PA1, PA2, PA3, PA4, PA5, PA6, PA7,
   ((PIN>=PC0)&&(PIN<=PC7) ? ( GPIOC->CFGLR =  (GPIOC->CFGLR                          \
                                            & ~((uint32_t)0b1111<<(((PIN)&7)<<2)))    \
                                            |  ((uint32_t)0b0001<<(((PIN)&7)<<2)) ) : \
-  ((PIN>=PC0)&&(PIN<=PC7) ? ( GPIOD->CFGLR =  (GPIOD->CFGLR                          \
+  ((PIN>=PD0)&&(PIN<=PD7) ? ( GPIOD->CFGLR =  (GPIOD->CFGLR                          \
                                            & ~((uint32_t)0b1111<<(((PIN)&7)<<2)))    \
                                            |  ((uint32_t)0b0001<<(((PIN)&7)<<2)) ) : \
 (0))))
@@ -170,7 +170,7 @@ enum{ PA0, PA1, PA2, PA3, PA4, PA5, PA6, PA7,
   ((PIN>=PC0)&&(PIN<=PC7) ? ( GPIOC->CFGLR =  (GPIOC->CFGLR                          \
                                            & ~((uint32_t)0b1111<<(((PIN)&7)<<2)))    \
                                            |  ((uint32_t)0b0101<<(((PIN)&7)<<2)) ) : \
-  ((PIN>=PC0)&&(PIN<=PC7) ? ( GPIOD->CFGLR =  (GPIOD->CFGLR                          \
+  ((PIN>=PD0)&&(PIN<=PD7) ? ( GPIOD->CFGLR =  (GPIOD->CFGLR                          \
                                            & ~((uint32_t)0b1111<<(((PIN)&7)<<2)))    \
                                            |  ((uint32_t)0b0101<<(((PIN)&7)<<2)) ) : \
 (0))))

--- a/software/tiny_lander/include/gpio.h
+++ b/software/tiny_lander/include/gpio.h
@@ -90,7 +90,7 @@ enum{ PA0, PA1, PA2, PA3, PA4, PA5, PA6, PA7,
   ((PIN>=PC0)&&(PIN<=PC7) ? ( GPIOC->CFGLR =  (GPIOC->CFGLR                          \
                                            & ~((uint32_t)0b1111<<(((PIN)&7)<<2)))    \
                                            |  ((uint32_t)0b0100<<(((PIN)&7)<<2)) ) : \
-  ((PIN>=PC0)&&(PIN<=PC7) ? ( GPIOD->CFGLR =  (GPIOD->CFGLR                          \
+  ((PIN>=PD0)&&(PIN<=PD7) ? ( GPIOD->CFGLR =  (GPIOD->CFGLR                          \
                                            & ~((uint32_t)0b1111<<(((PIN)&7)<<2)))    \
                                            |  ((uint32_t)0b0100<<(((PIN)&7)<<2)) ) : \
 (0))))
@@ -154,7 +154,7 @@ enum{ PA0, PA1, PA2, PA3, PA4, PA5, PA6, PA7,
   ((PIN>=PC0)&&(PIN<=PC7) ? ( GPIOC->CFGLR =  (GPIOC->CFGLR                          \
                                            & ~((uint32_t)0b1111<<(((PIN)&7)<<2)))    \
                                            |  ((uint32_t)0b0001<<(((PIN)&7)<<2)) ) : \
-  ((PIN>=PC0)&&(PIN<=PC7) ? ( GPIOD->CFGLR =  (GPIOD->CFGLR                          \
+  ((PIN>=PD0)&&(PIN<=PD7) ? ( GPIOD->CFGLR =  (GPIOD->CFGLR                          \
                                            & ~((uint32_t)0b1111<<(((PIN)&7)<<2)))    \
                                            |  ((uint32_t)0b0001<<(((PIN)&7)<<2)) ) : \
 (0))))
@@ -170,7 +170,7 @@ enum{ PA0, PA1, PA2, PA3, PA4, PA5, PA6, PA7,
   ((PIN>=PC0)&&(PIN<=PC7) ? ( GPIOC->CFGLR =  (GPIOC->CFGLR                          \
                                            & ~((uint32_t)0b1111<<(((PIN)&7)<<2)))    \
                                            |  ((uint32_t)0b0101<<(((PIN)&7)<<2)) ) : \
-  ((PIN>=PC0)&&(PIN<=PC7) ? ( GPIOD->CFGLR =  (GPIOD->CFGLR                          \
+  ((PIN>=PD0)&&(PIN<=PD7) ? ( GPIOD->CFGLR =  (GPIOD->CFGLR                          \
                                            & ~((uint32_t)0b1111<<(((PIN)&7)<<2)))    \
                                            |  ((uint32_t)0b0101<<(((PIN)&7)<<2)) ) : \
 (0))))

--- a/software/tiny_pacman/include/gpio.h
+++ b/software/tiny_pacman/include/gpio.h
@@ -90,7 +90,7 @@ enum{ PA0, PA1, PA2, PA3, PA4, PA5, PA6, PA7,
   ((PIN>=PC0)&&(PIN<=PC7) ? ( GPIOC->CFGLR =  (GPIOC->CFGLR                          \
                                            & ~((uint32_t)0b1111<<(((PIN)&7)<<2)))    \
                                            |  ((uint32_t)0b0100<<(((PIN)&7)<<2)) ) : \
-  ((PIN>=PC0)&&(PIN<=PC7) ? ( GPIOD->CFGLR =  (GPIOD->CFGLR                          \
+  ((PIN>=PD0)&&(PIN<=PD7) ? ( GPIOD->CFGLR =  (GPIOD->CFGLR                          \
                                            & ~((uint32_t)0b1111<<(((PIN)&7)<<2)))    \
                                            |  ((uint32_t)0b0100<<(((PIN)&7)<<2)) ) : \
 (0))))
@@ -154,7 +154,7 @@ enum{ PA0, PA1, PA2, PA3, PA4, PA5, PA6, PA7,
   ((PIN>=PC0)&&(PIN<=PC7) ? ( GPIOC->CFGLR =  (GPIOC->CFGLR                          \
                                            & ~((uint32_t)0b1111<<(((PIN)&7)<<2)))    \
                                            |  ((uint32_t)0b0001<<(((PIN)&7)<<2)) ) : \
-  ((PIN>=PC0)&&(PIN<=PC7) ? ( GPIOD->CFGLR =  (GPIOD->CFGLR                          \
+  ((PIN>=PD0)&&(PIN<=PD7) ? ( GPIOD->CFGLR =  (GPIOD->CFGLR                          \
                                            & ~((uint32_t)0b1111<<(((PIN)&7)<<2)))    \
                                            |  ((uint32_t)0b0001<<(((PIN)&7)<<2)) ) : \
 (0))))
@@ -170,7 +170,7 @@ enum{ PA0, PA1, PA2, PA3, PA4, PA5, PA6, PA7,
   ((PIN>=PC0)&&(PIN<=PC7) ? ( GPIOC->CFGLR =  (GPIOC->CFGLR                          \
                                            & ~((uint32_t)0b1111<<(((PIN)&7)<<2)))    \
                                            |  ((uint32_t)0b0101<<(((PIN)&7)<<2)) ) : \
-  ((PIN>=PC0)&&(PIN<=PC7) ? ( GPIOD->CFGLR =  (GPIOD->CFGLR                          \
+  ((PIN>=PD0)&&(PIN<=PD7) ? ( GPIOD->CFGLR =  (GPIOD->CFGLR                          \
                                            & ~((uint32_t)0b1111<<(((PIN)&7)<<2)))    \
                                            |  ((uint32_t)0b0101<<(((PIN)&7)<<2)) ) : \
 (0))))

--- a/software/tiny_tris/include/gpio.h
+++ b/software/tiny_tris/include/gpio.h
@@ -90,7 +90,7 @@ enum{ PA0, PA1, PA2, PA3, PA4, PA5, PA6, PA7,
   ((PIN>=PC0)&&(PIN<=PC7) ? ( GPIOC->CFGLR =  (GPIOC->CFGLR                          \
                                            & ~((uint32_t)0b1111<<(((PIN)&7)<<2)))    \
                                            |  ((uint32_t)0b0100<<(((PIN)&7)<<2)) ) : \
-  ((PIN>=PC0)&&(PIN<=PC7) ? ( GPIOD->CFGLR =  (GPIOD->CFGLR                          \
+  ((PIN>=PD0)&&(PIN<=PD7) ? ( GPIOD->CFGLR =  (GPIOD->CFGLR                          \
                                            & ~((uint32_t)0b1111<<(((PIN)&7)<<2)))    \
                                            |  ((uint32_t)0b0100<<(((PIN)&7)<<2)) ) : \
 (0))))
@@ -154,7 +154,7 @@ enum{ PA0, PA1, PA2, PA3, PA4, PA5, PA6, PA7,
   ((PIN>=PC0)&&(PIN<=PC7) ? ( GPIOC->CFGLR =  (GPIOC->CFGLR                          \
                                            & ~((uint32_t)0b1111<<(((PIN)&7)<<2)))    \
                                            |  ((uint32_t)0b0001<<(((PIN)&7)<<2)) ) : \
-  ((PIN>=PC0)&&(PIN<=PC7) ? ( GPIOD->CFGLR =  (GPIOD->CFGLR                          \
+  ((PIN>=PD0)&&(PIN<=PD7) ? ( GPIOD->CFGLR =  (GPIOD->CFGLR                          \
                                            & ~((uint32_t)0b1111<<(((PIN)&7)<<2)))    \
                                            |  ((uint32_t)0b0001<<(((PIN)&7)<<2)) ) : \
 (0))))
@@ -170,7 +170,7 @@ enum{ PA0, PA1, PA2, PA3, PA4, PA5, PA6, PA7,
   ((PIN>=PC0)&&(PIN<=PC7) ? ( GPIOC->CFGLR =  (GPIOC->CFGLR                          \
                                            & ~((uint32_t)0b1111<<(((PIN)&7)<<2)))    \
                                            |  ((uint32_t)0b0101<<(((PIN)&7)<<2)) ) : \
-  ((PIN>=PC0)&&(PIN<=PC7) ? ( GPIOD->CFGLR =  (GPIOD->CFGLR                          \
+  ((PIN>=PD0)&&(PIN<=PD7) ? ( GPIOD->CFGLR =  (GPIOD->CFGLR                          \
                                            & ~((uint32_t)0b1111<<(((PIN)&7)<<2)))    \
                                            |  ((uint32_t)0b0101<<(((PIN)&7)<<2)) ) : \
 (0))))


### PR DESCRIPTION
Probably just typos. Great library for CH32V003 GPIO! Thank you!